### PR TITLE
alphalm: overlay: Move rounded corner overlays to frameworks

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/dimens.xml
+++ b/overlay/frameworks/base/core/res/res/values/dimens.xml
@@ -16,6 +16,9 @@
 */
 -->
 <resources>
+    <!-- Default radius of the software rounded corners. -->
     <dimen name="rounded_corner_radius">26dp</dimen>
+
+    <!-- Default paddings for content around the corners. -->
     <dimen name="rounded_corner_content_padding">12dp</dimen>
 </resources>


### PR DESCRIPTION
* According to https://github.com/LineageOS/android_frameworks_base/blob/36da5963cfa1777bb6bca06e382a41e26ca625a0/core/res/res/values/dimens.xml#L113